### PR TITLE
Add functions

### DIFF
--- a/moist_thermodynamics/functions.py
+++ b/moist_thermodynamics/functions.py
@@ -636,6 +636,18 @@ def get_n2(th, qv, z, axis=None):
     return np.sqrt(g * (dlnthdz + (Rv - Rd) / R * dqvdz))
 
 
+def hydrostatic_altitude_np(p, T, q):
+    Rv = constants.water_vapor_gas_constant
+    Rd = constants.dry_air_gas_constant
+    g = constants.gravity_earth
+
+    qbar = (q[:-1] + q[1:]) / 2
+    Tbar = (T[:-1] + T[1:]) / 2
+    dz = -(Rd + (Rv - Rd) * qbar) * Tbar * np.diff(np.log(p)) / g
+
+    return np.insert(np.cumsum(dz, axis=0), 0, 0)
+
+
 def moist_adiabat(
     Tbeg,
     Pbeg,

--- a/moist_thermodynamics/functions.py
+++ b/moist_thermodynamics/functions.py
@@ -615,6 +615,27 @@ def zlcl(Plcl, T, P, qt, z):
     return T * (1.0 - (Plcl / P) ** (R / cp)) * cp / g + z
 
 
+def get_n2(th, qv, z, axis=None):
+    """Returns the Brunt-Vaisala frequeny for unsaturated air.
+
+    It assumes that the air is nowhere saturated.
+
+    Args:
+        th: potential temperature
+        qv: specific humidity
+        z: height
+    """
+
+    Rv = constants.water_vapor_gas_constant
+    Rd = constants.dry_air_gas_constant
+    g = constants.gravity_earth
+    R = Rd + (Rv - Rd) * qv
+    dlnthdz = np.gradient(np.log(th), z, axis=axis)
+    dqvdz = np.gradient(qv, z, axis=axis)
+
+    return np.sqrt(g * (dlnthdz + (Rv - Rd) / R * dqvdz))
+
+
 def moist_adiabat(
     Tbeg,
     Pbeg,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -47,3 +47,12 @@ def test_n2():
     expected_n2 = np.array(stability_data[3])
     n2 = mtf.get_n2(th, qv, z)
     assert pytest.approx(n2, 1e-5) == expected_n2
+
+
+def test_hydrostatic_altitude():
+    P = np.linspace(100000, 80000, 5)
+    T = np.full(5, 299.5)
+    q = np.full(5, 0.018)
+    expected = np.array([0.0, 454.57587378, 933.73508251, 1440.28932562, 1977.56209712])
+    z = mtf.hydrostatic_altitude_np(P, T, q)
+    assert pytest.approx(z, 1e-5) == expected

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,6 +15,13 @@ data = [
     ],
 ]
 
+stability_data = [
+    [300, 315, 320],
+    [0.016, 0.008, 0.004],
+    [0, 2000, 4000],
+    [0.01468398, 0.01185031, 0.00808245],
+]
+
 
 @pytest.mark.parametrize("T, p, qt", data)
 def test_invert_T(T, p, qt):
@@ -31,3 +38,12 @@ def test_plcl(T, p, qt):
         print(res)
         assert np.all(res[:-1] - res[1:] < 0)
         assert abs(res[-1] - 95994.43612848) < 1
+
+
+def test_n2():
+    th = np.array(stability_data[0])
+    qv = np.array(stability_data[1])
+    z = np.array(stability_data[2])
+    expected_n2 = np.array(stability_data[3])
+    n2 = mtf.get_n2(th, qv, z)
+    assert pytest.approx(n2, 1e-5) == expected_n2

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from moist_thermodynamics import functions as mtf
-from moist_thermodynamics.saturation_vapor_pressures import es_default
+from moist_thermodynamics.saturation_vapor_pressures import es_default, liq_wagner_pruss
 
 es = es_default
 
@@ -29,6 +29,33 @@ def test_invert_T(T, p, qt):
     temp = mtf.invert_for_temperature(mtf.theta_l, Tl, p, qt, es=es)
 
     np.testing.assert_array_equal(temp, T)
+
+
+@pytest.mark.parametrize(
+    "Tbeg, Pbeg, Pend, dP, qt",
+    [
+        (300, 100000, 10000, 10000, 0.018),
+        (
+            np.array([300]),
+            np.array([100000]),
+            np.array([10000]),
+            np.array([10000]),
+            np.array([0.018]),
+        ),
+        (
+            np.array([[300]]),
+            np.array([[100000]]),
+            np.array([[10000]]),
+            np.array([[10000]]),
+            np.array([[0.018]]),
+        ),
+    ],
+)
+def test_moist_adiabat(Tbeg, Pbeg, Pend, dP, qt):
+    T, p = mtf.moist_adiabat(Tbeg, Pbeg, Pend, dP, qt, es=liq_wagner_pruss)
+    assert T.shape == (9,)
+    assert np.all(p == [100000, 90000, 80000, 70000, 60000, 50000, 40000, 30000, 20000])
+    assert np.all(np.diff(T) < 0)
 
 
 @pytest.mark.parametrize("T, p, qt", data)


### PR DESCRIPTION
This PR adds 
 - a function to calculate the Brunt-Vaisala frequency
 - a function to calculate hydrostatic altitudes

It also changes the calculation for the `moist_adiabat` to accept both arrays and values as input and changes the solver. The last part needs checking as the ode that it was before would take forever for the test case. @bjorn-stevens  could you check?

I also tried to add simple test cases for each of those functions, although the test for the `moist_adiabat` does not really test much of value.